### PR TITLE
[SRE-8511] Change security group rule resource type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Compiled files
 *.tfstate
 *.tfstate.backup
+.idea

--- a/security_group.tf
+++ b/security_group.tf
@@ -8,22 +8,20 @@ resource "aws_security_group" "aurora_security_group" {
   }
 }
 
-resource "aws_security_group_rule" "aurora_ingress" {
-  count                    = length(var.allowed_security_groups)
-  type                     = "ingress"
-  from_port                = var.db_port
-  to_port                  = var.db_port
-  protocol                 = "tcp"
-  source_security_group_id = element(var.allowed_security_groups, count.index)
-  security_group_id        = aws_security_group.aurora_security_group.id
+resource "aws_vpc_security_group_ingress_rule" "aurora_sgs" {
+  for_each                     = toset(var.allowed_security_groups)
+  security_group_id            = aws_security_group.aurora_security_group.id
+  referenced_security_group_id = each.value
+  from_port                    = var.db_port
+  to_port                      = var.db_port
+  ip_protocol                  = "tcp"
 }
 
-resource "aws_security_group_rule" "aurora_networks_ingress" {
-  type              = "ingress"
+resource "aws_vpc_security_group_ingress_rule" "aurora_cidrs" {
+  for_each          = toset(var.allowed_cidr)
+  security_group_id = aws_security_group.aurora_security_group.id
+  cidr_ipv4         = each.value
   from_port         = var.db_port
   to_port           = var.db_port
-  protocol          = "tcp"
-  cidr_blocks       = var.allowed_cidr
-  security_group_id = aws_security_group.aurora_security_group.id
+  ip_protocol       = "tcp"
 }
-


### PR DESCRIPTION
Replace the `aws_security_group_rule` resource type with `aws_vpc_security_group_ingress_rule`

This is based on the provider's own recommendation and makes updating SGs less destructive.